### PR TITLE
Remove references to fgeo.x

### DIFF
--- a/R/fgeo_pkgs.R
+++ b/R/fgeo_pkgs.R
@@ -30,8 +30,7 @@ fgeo_core <- function() {
     "fgeo.ctfs",
     "fgeo.habitat",
     "fgeo.map",
-    "fgeo.tool",
-    "fgeo.x"
+    "fgeo.tool"
   )
 }
 

--- a/tests/testthat/test-fgeo_dependencies.R
+++ b/tests/testthat/test-fgeo_dependencies.R
@@ -4,15 +4,11 @@ test_that("is sensitive to `matches`", {
   expect_true(any(grepl("^cli$", fgeo_dependencies())))
   expect_false(any(grepl("^cli$", fgeo_dependencies(matches = "fgeo"))))
   expect_true(any(grepl("^fgeo$", fgeo_dependencies(matches = "fgeo"))))
-  expect_true(any(grepl("^fgeo.x$", fgeo_dependencies(matches = "fgeo"))))
 })
 
 test_that("is sensitive to `include_fgeo`", {
   expect_false(
     any(grepl("^fgeo$", fgeo_dependencies("fgeo", include_self = FALSE)))
-  )
-  expect_true(
-    any(grepl("^fgeo.x$", fgeo_dependencies("fgeo", include_self = FALSE)))
   )
 })
 

--- a/tests/testthat/test-fgeo_pkgs.R
+++ b/tests/testthat/test-fgeo_pkgs.R
@@ -3,7 +3,6 @@ context("fgeo_pkgs")
 test_that("is sensitive to `include_self`", {
 
   pkgs <- c(
-      "fgeo.x",
       "fgeo.ctfs",
       "fgeo.tool",
       "fgeo.map",
@@ -21,8 +20,7 @@ test_that("is sensitive to `include_self`", {
     "fgeo.ctfs",
     "fgeo.habitat",
     "fgeo.map",
-    "fgeo.tool",
-    "fgeo.x"
+    "fgeo.tool"
   )
   expect_equal(fgeo_core(), core)
 })


### PR DESCRIPTION
Dont merge until tests pass -- i.e. when all other packages have excluded __fgeo.x__.
